### PR TITLE
🔄 Fix casing in route function names

### DIFF
--- a/fastauth/routes.py
+++ b/fastauth/routes.py
@@ -10,7 +10,7 @@ from fastapi.exceptions import HTTPException
 def AuthRoutes(database: fastauth._Redis, router: fastauth._APIRouter):
 
     @router.get("/user/{userID}", response_model=UUID)
-    async def getUser(userID: UUID):
+    async def get_user(userID: UUID):
         return userID
 
     @router.post("/login")


### PR DESCRIPTION
Corrected the case of route function names from camelCase to snake_case, following PEP 8 convention.